### PR TITLE
Fix build error resulting from ungrouped logical comparison

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1896,7 +1896,7 @@ void find_ammo_helper( T &src, const item &obj, bool empty, Output out, bool nes
                     return VisitResponse::SKIP;
                 }
 
-                if( parent->is_container() && node->made_of( LIQUID ) || node->is_frozen_liquid() ) {
+                if( (parent->is_container() && node->made_of( LIQUID )) || node->is_frozen_liquid() ) {
                     out = item_location( src, node );
                 }
                 return nested ? VisitResponse::NEXT : VisitResponse::SKIP;


### PR DESCRIPTION
Fixes the following build error:

```
[ 11%] Building CXX object src/CMakeFiles/libcataclysm.dir/clothing_mod.cpp.o
[ 11%] Linking CXX executable ../../../json_formatter
[ 11%] Built target json_formatter
[ 11%] Building CXX object src/CMakeFiles/libcataclysm.dir/clzones.cpp.o
[ 11%] Building CXX object src/CMakeFiles/libcataclysm.dir/color.cpp.o
/home/damien/workspace/Cataclysm-DDA/src/character.cpp:1899:44: error: '&&' within '||' [-Werror,-Wlogical-op-parenthe
ses]
                if( parent->is_container() && node->made_of( LIQUID ) || node->is_frozen_liquid() ) {
                    ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~ ~~
/home/damien/workspace/Cataclysm-DDA/src/character.cpp:1899:44: note: place parentheses around the '&&' expression to
silence this warning
                if( parent->is_container() && node->made_of( LIQUID ) || node->is_frozen_liquid() ) {
                                           ^
                    (                                                )
1 error generated.
src/CMakeFiles/libcataclysm.dir/build.make:906: recipe for target 'src/CMakeFiles/libcataclysm.dir/character.cpp.o' fa
iled
make[2]: *** [src/CMakeFiles/libcataclysm.dir/character.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
CMakeFiles/Makefile2:1234: recipe for target 'src/CMakeFiles/libcataclysm.dir/all' failed
make[1]: *** [src/CMakeFiles/libcataclysm.dir/all] Error 2
Makefile:94: recipe for target 'all' failed
make: *** [all] Error 2
```