### PR TITLE
Fix iuse tests

### DIFF
--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -18,8 +18,8 @@ static const std::string flag_WET( "WET" );
 TEST_CASE( "eyedrops", "[iuse][eyedrops]" )
 {
     avatar dummy;
+    item eyedrops( "saline", 0, item::default_charges_tag{} );
 
-    item &eyedrops = dummy.i_add( item( "saline", 0, item::default_charges_tag{} ) );
     int charges_before = eyedrops.charges;
     REQUIRE( charges_before > 0 );
 
@@ -56,7 +56,8 @@ TEST_CASE( "eyedrops", "[iuse][eyedrops]" )
 TEST_CASE( "antifungal", "[iuse][antifungal]" )
 {
     avatar dummy;
-    item &antifungal = dummy.i_add( item( "antifungal", 0, item::default_charges_tag{} ) );
+    item antifungal( "antifungal", 0, item::default_charges_tag{} );
+
     int charges_before = antifungal.charges;
     REQUIRE( charges_before > 0 );
 
@@ -98,7 +99,7 @@ TEST_CASE( "antifungal", "[iuse][antifungal]" )
 TEST_CASE( "antiparasitic", "[iuse][antiparasitic]" )
 {
     avatar dummy;
-    item &antiparasitic = dummy.i_add( item( "antiparasitic", 0, item::default_charges_tag{} ) );
+    item antiparasitic( "antiparasitic", 0, item::default_charges_tag{} );
 
     int charges_before = antiparasitic.charges;
     REQUIRE( charges_before > 0 );
@@ -154,7 +155,7 @@ TEST_CASE( "antiparasitic", "[iuse][antiparasitic]" )
 TEST_CASE( "anticonvulsant", "[iuse][anticonvulsant]" )
 {
     avatar dummy;
-    item &anticonvulsant = dummy.i_add( item( "diazepam", 0, item::default_charges_tag{} ) );
+    item anticonvulsant( "diazepam", 0, item::default_charges_tag{} );
 
     int charges_before = anticonvulsant.charges;
     REQUIRE( charges_before > 0 );
@@ -187,7 +188,7 @@ TEST_CASE( "anticonvulsant", "[iuse][anticonvulsant]" )
 TEST_CASE( "oxygen tank", "[iuse][oxygen_bottle]" )
 {
     avatar dummy;
-    item &oxygen = dummy.i_add( item( "oxygen_tank", 0, item::default_charges_tag{} ) );
+    item oxygen( "oxygen_tank", 0, item::default_charges_tag{} );
 
     int charges_before = oxygen.charges;
     REQUIRE( charges_before > 0 );
@@ -287,7 +288,6 @@ TEST_CASE( "oxygen tank", "[iuse][oxygen_bottle]" )
 TEST_CASE( "caffeine and atomic caffeine", "[iuse][caff][atomic_caff]" )
 {
     avatar dummy;
-    dummy.worn.push_back( item( "backpack" ) );
 
     // Baseline fatigue level before caffeinating
     int fatigue_before = 200;
@@ -300,16 +300,14 @@ TEST_CASE( "caffeine and atomic caffeine", "[iuse][caff][atomic_caff]" )
     REQUIRE( dummy.get_rad() == 0 );
 
     SECTION( "coffee reduces fatigue, but does not give stimulant effect" ) {
-        item &coffee_container = dummy.i_add( item( "coffee", 0, item::default_charges_tag{} ).in_its_container() );
-        item &coffee = coffee_container.contents.only_item();
+        item coffee( "coffee", 0, item::default_charges_tag{} );
         dummy.consume_item( coffee );
         CHECK( dummy.get_fatigue() == fatigue_before - coffee.get_comestible()->fatigue_mod );
         CHECK( dummy.get_stim() == coffee.get_comestible()->stim );
     }
 
     SECTION( "atomic caffeine greatly reduces fatigue, and increases stimulant effect" ) {
-        item &atomic_coffee_container = dummy.i_add( item( "atomic_coffee", 0, item::default_charges_tag{} ).in_its_container() );
-        item &atomic_coffee = atomic_coffee_container.contents.only_item();
+        item atomic_coffee( "atomic_coffee", 0, item::default_charges_tag{} );
         dummy.consume_item( atomic_coffee );
         CHECK( dummy.get_fatigue() == fatigue_before - atomic_coffee.get_comestible()->fatigue_mod );
         CHECK( dummy.get_stim() == atomic_coffee.get_comestible()->stim );
@@ -319,8 +317,7 @@ TEST_CASE( "caffeine and atomic caffeine", "[iuse][caff][atomic_caff]" )
 TEST_CASE( "towel", "[iuse][towel]" )
 {
     avatar dummy;
-
-    item &towel = dummy.i_add( item( "towel", 0, item::default_charges_tag{} ) );
+    item towel( "towel", 0, item::default_charges_tag{} );
 
     GIVEN( "avatar is wet" ) {
         // Saturate torso, head, and both arms
@@ -441,7 +438,8 @@ TEST_CASE( "thorazine", "[iuse][thorazine]" )
 {
     avatar dummy;
     dummy.set_fatigue( 0 );
-    item &thorazine = dummy.i_add( item( "thorazine", 0, item::default_charges_tag{} ) );
+    item thorazine( "thorazine", 0, item::default_charges_tag{} );
+
     int charges_before = thorazine.charges;
     REQUIRE( charges_before >= 2 );
 
@@ -488,7 +486,7 @@ TEST_CASE( "thorazine", "[iuse][thorazine]" )
 TEST_CASE( "prozac", "[iuse][prozac]" )
 {
     avatar dummy;
-    item &prozac = dummy.i_add( item( "prozac", 0, item::default_charges_tag{} ) );
+    item prozac( "prozac", 0, item::default_charges_tag{} );
 
     SECTION( "prozac gives prozac and visible prozac effect" ) {
         REQUIRE_FALSE( dummy.has_effect( efftype_id( "took_prozac" ) ) );
@@ -512,7 +510,7 @@ TEST_CASE( "prozac", "[iuse][prozac]" )
 TEST_CASE( "inhaler", "[iuse][inhaler]" )
 {
     avatar dummy;
-    item &inhaler = dummy.i_add( item( "inhaler", 0, item::default_charges_tag{} ) );
+    item inhaler( "inhaler", 0, item::default_charges_tag{} );
 
     GIVEN( "avatar is suffering from smoke inhalation" ) {
         dummy.add_effect( efftype_id( "smoke" ), 1_hours );
@@ -548,7 +546,7 @@ TEST_CASE( "inhaler", "[iuse][inhaler]" )
 TEST_CASE( "royal jelly", "[iuse][royal_jelly]" )
 {
     avatar dummy;
-    item &jelly = dummy.i_add( item( "royal_jelly", 0, item::default_charges_tag{} ) );
+    item jelly( "royal_jelly", 0, item::default_charges_tag{} );
 
     SECTION( "royal jelly gives cure-all effect" ) {
         REQUIRE_FALSE( dummy.has_effect( efftype_id( "cureall" ) ) );
@@ -561,7 +559,7 @@ TEST_CASE( "royal jelly", "[iuse][royal_jelly]" )
 TEST_CASE( "xanax", "[iuse][xanax]" )
 {
     avatar dummy;
-    item &xanax = dummy.i_add( item( "xanax", 0, item::default_charges_tag{} ) );
+    item xanax( "xanax", 0, item::default_charges_tag{} );
 
     SECTION( "xanax gives xanax and visible xanax effects" ) {
         REQUIRE_FALSE( dummy.has_effect( efftype_id( "took_xanax" ) ) );


### PR DESCRIPTION
Get all the iuse tests passing again.

Using `i_add` for these test cases appears to run into complications with needing a container for liquids, and storage in inventory for the item. These considerations get in the way of what we're testing, which is simply the effects of using various items, and this can be done without putting the item in the inventory.
