### PR TITLE
Avoid copying in range-based for loops

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2705,7 +2705,7 @@ units::mass Character::weight_carried_with_tweaks( const std::vector<std::pair<i
         &locations ) const
 {
     std::map<const item *, int> dropping;
-    for( const std::pair<const item_location, int> &location_pair : locations ) {
+    for( const std::pair<item_location, int> &location_pair : locations ) {
         dropping.emplace( location_pair.first.get_item(), location_pair.second );
     }
     return weight_carried_with_tweaks( { dropping } );
@@ -2767,7 +2767,7 @@ units::volume Character::volume_carried_with_tweaks( const
         &locations ) const
 {
     std::map<const item *, int> dropping;
-    for( const std::pair<const item_location, int> &location_pair : locations ) {
+    for( const std::pair<item_location, int> &location_pair : locations ) {
         dropping.emplace( location_pair.first.get_item(), location_pair.second );
     }
     return volume_carried_with_tweaks( { dropping } );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -537,7 +537,7 @@ const inventory &Character::crafting_inventory( const tripoint &src_pos, int rad
     cached_crafting_inventory.clear();
     cached_crafting_inventory.form_from_map( inv_pos, radius, this, false, clear_path );
 
-    for( const item_location it : all_items_loc() ) {
+    for( const item_location &it : all_items_loc() ) {
         // can't craft with containers that have items in them
         if( !it->contents.empty_container() ) {
             continue;

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2157,7 +2157,7 @@ void Item_factory::check_and_create_magazine_pockets( itype &def )
     if( def.magazine ) {
         pocket_data mag_data;
         mag_data.type = item_pocket::pocket_type::MAGAZINE;
-        for( const ammotype amtype : def.magazine->type ) {
+        for( const ammotype &amtype : def.magazine->type ) {
             mag_data.ammo_restriction.emplace( amtype, def.magazine->capacity );
         }
         mag_data.fire_protection = def.magazine->protects_contents;


### PR DESCRIPTION
I'm pretty sure these are only from your changes and won't cause merge conflicts.