### PR TITLE
Grey Committee

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1754,8 +1754,6 @@ void Character::process_turn()
     }
 
     Creature::process_turn();
-
-    enchantment_cache->activate_passive( *this );
 }
 
 void Character::recalc_hp()


### PR DESCRIPTION
We are the Grey Committee.

 

Cataclysm started as great Community Project. But recent events indicate that normal and healthy relationship between Community and Developers are lost and development going nowhere. Main reason of this is Kevin Grenade.

 

Kevin Grenade, current Project Leader deemed exclusively rights on everything in Cataclysm, violating project license and intellectual honesty.

 

He does not respect community opinion and opinion of his own development team alike. Reasoning with him became pointless long time ago. A lot of people left project because of his attitude and decision making.

 

Worse of all that project development start going with questionable ways at best. Instead of proper and logical decision making changes start becoming more and more chaotic and subjective. Game becoming a mess.

 

So we are decided that time for compromises has passed. The Grey Committee was created to fight back.

 

Our Manifesto is simple:

1) Kevin Grenade must leave the project forever.

2) New Development Leader must re-establish normal relation between Development Team and Community.

3) All bans since beginning Kevin Grenade leadership must be revoked.

 

This goals are not negotiable and can be considered as our ultimatum.

 

To achieve our goals, we will engage Kevin Grenade and ones who blindly supports his behavior in various ways of informational and psychological warfare.

 

We are not going allow some false dictator to steal our project and reduce it to dust.

 

«In the struggle you will gain your rights»

Grey Committee.